### PR TITLE
fix: fix the bug of online serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ vllm serve \
     --gpu-memory-utilization 0.8 \
     --host 0.0.0.0 \
     --port 8000 \
+    --max-num-batched-tokens 80960 \
+    --max-model-len 80960 \
     --trust-remote-code
 ```
 
@@ -358,7 +360,7 @@ def prepare_message_for_vllm(content_messages):
         for part_message in message_content_list:
             if 'video' in part_message:
                 video_message = [{'content': [part_message]}]
-                image_inputs, video_inputs, video_kwargs = process_vision_info(video_message, return_video_kwargs=True)
+                image_inputs, video_inputs, video_kwargs = process_vision_info(video_message)
                 assert video_inputs is not None, "video_inputs should not be None"
                 video_input = (video_inputs.pop()).permute(0, 2, 3, 1).numpy().astype(np.uint8)
                 fps_list.extend(video_kwargs.get('fps', []))


### PR DESCRIPTION
# PR: Fix TypeError in Online Serving + vLLM video inference parameters
Hi Kwai Team, thank you for the great work and for reviewing this PR.
- Related issue: https://github.com/Kwai-Keye/Keye/issues/42

## Summary
- Fix a TypeError in the Online Serving demo caused by passing an unsupported `return_video_kwargs` argument to `process_vision_info`.
- Add recommended vLLM serve flags for stable video inference.

## Changes
- Remove `return_video_kwargs=True` from the demo/serving code.
- Keep the call as:
  ```python
  image_inputs, video_inputs, video_kwargs = process_vision_info(video_message)
  ```
  The function already returns `video_kwargs`.

## Rationale
- `process_vision_info` in `src/keye_vl_utils/vision_process.py` doesn’t accept `return_video_kwargs`; passing it raises:
  ```
  TypeError: process_vision_info() got an unexpected keyword argument 'return_video_kwargs'
  ```

## vLLM Notes (to avoid freezes with long videos)
```bash
vllm serve Kwai-Keye/Keye-VL-8B-Preview \
  --tensor-parallel-size 1 \
  --enable-prefix-caching \
  --gpu-memory-utilization 0.6 \
  --host 0.0.0.0 \
  --port 8000 \
  --max-num-batched-tokens 80960 \
  --max-model-len 80960 \
  --trust-remote-code
```
- `--max-num-batched-tokens 80960`: avoids batching issues with long sequences  
- `--max-model-len 80960`: supports extended context from video frames

## Testing
- Re-ran the Online Serving demo with a sample video.
- Verified:
  - No TypeError occurs.
  - Chat completion succeeds.